### PR TITLE
ch11 resolver

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -43,6 +43,23 @@ impl<'a> Environment<'a> {
         }
     }
 
+    pub(crate) fn get_global(&self, name: &'a str) -> Option<Value<'a>> {
+        match &self.enclosing {
+            Some(enclosing) => enclosing.borrow().get_global(name),
+            None => self.get(name),
+        }
+    }
+
+    pub(crate) fn get_at(&self, name: &'a str, distance: usize) -> Option<Value<'a>> {
+        match distance {
+            0 => self.get(name),
+            d => match &self.enclosing {
+                Some(enclosing) => enclosing.borrow().get_at(name, d - 1),
+                None => None,
+            },
+        }
+    }
+
     pub(crate) fn assign(&mut self, name: &'a str, value: Value<'a>) -> Option<Value<'a>> {
         if self.values.contains_key(name) {
             return self.values.insert(name, value);
@@ -51,6 +68,28 @@ impl<'a> Environment<'a> {
         match &self.enclosing {
             Some(enc) => enc.borrow_mut().assign(name, value),
             None => None,
+        }
+    }
+
+    pub(crate) fn assign_global(&mut self, name: &'a str, value: Value<'a>) -> Option<Value<'a>> {
+        match &self.enclosing {
+            Some(enclosing) => enclosing.borrow_mut().assign_global(name, value),
+            None => self.assign(name, value),
+        }
+    }
+
+    pub(crate) fn assign_at(
+        &mut self,
+        name: &'a str,
+        value: Value<'a>,
+        distance: usize,
+    ) -> Option<Value<'a>> {
+        match distance {
+            0 => self.assign(name, value),
+            d => match &self.enclosing {
+                Some(enclosing) => enclosing.borrow_mut().assign_at(name, value, d - 1),
+                None => None,
+            },
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -194,6 +194,12 @@ pub enum ResolverError {
         #[label("{}", self)]
         span: SourceSpan,
     },
+
+    #[error("Can't return from top-level code")]
+    TopLevelReturn {
+        #[label("{}", self)]
+        span: SourceSpan,
+    },
 }
 
 impl ResolverError {
@@ -219,6 +225,10 @@ impl ResolverError {
             span: span.into(),
         }
         .into()
+    }
+
+    pub fn top_level_return(span: Span) -> BolloxError {
+        Self::TopLevelReturn { span: span.into() }.into()
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,10 @@ pub enum BolloxError {
 
     #[error(transparent)]
     #[diagnostic(transparent)]
+    ResolverError(#[from] ResolverError),
+
+    #[error(transparent)]
+    #[diagnostic(transparent)]
     RuntimeError(#[from] RuntimeError),
 }
 
@@ -165,6 +169,26 @@ impl SyntaxError {
 
     pub fn too_many_arguments(span: Span) -> BolloxError {
         Self::TooManyArguments { span: span.into() }.into()
+    }
+}
+
+#[derive(Clone, Debug, Error, Diagnostic)]
+pub enum ResolverError {
+    #[error("Variable is declared, but not yet defined: `{}`.", name)]
+    UndefinedVariable {
+        name: String,
+        #[label("{}", self)]
+        span: SourceSpan,
+    },
+}
+
+impl ResolverError {
+    pub fn undefined_variable(name: impl Into<String>, span: Span) -> BolloxError {
+        Self::UndefinedVariable {
+            name: name.into(),
+            span: span.into(),
+        }
+        .into()
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -180,11 +180,41 @@ pub enum ResolverError {
         #[label("{}", self)]
         span: SourceSpan,
     },
+
+    #[error("Variable already defined in this scope: `{}`", name)]
+    RedefinedVariable {
+        name: String,
+        #[label("{}", self)]
+        span: SourceSpan,
+    },
+
+    #[error("Function already defined in this scope: `{}`", name)]
+    RedefinedFunction {
+        name: String,
+        #[label("{}", self)]
+        span: SourceSpan,
+    },
 }
 
 impl ResolverError {
     pub fn undefined_variable(name: impl Into<String>, span: Span) -> BolloxError {
         Self::UndefinedVariable {
+            name: name.into(),
+            span: span.into(),
+        }
+        .into()
+    }
+
+    pub fn redefined_variable(name: impl Into<String>, span: Span) -> BolloxError {
+        Self::RedefinedVariable {
+            name: name.into(),
+            span: span.into(),
+        }
+        .into()
+    }
+
+    pub fn redefined_function(name: impl Into<String>, span: Span) -> BolloxError {
+        Self::RedefinedFunction {
             name: name.into(),
             span: span.into(),
         }

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -1,21 +1,24 @@
+use std::collections::HashMap;
+
 use crate::{
     callable::{Callable, Function},
     env::{Environment, EnvironmentRef},
     error::{BolloxError, RuntimeError, SyntaxError},
     expr::{BinaryOp, Expr, ExprNode, LogicalOp, UnaryOp},
     stmt::{Stmt, StmtNode},
+    token::Span,
     value::Value,
     Result,
 };
 
 pub fn interpreter<'a, I>(
     statements: I,
-    _context: InterpreterContext<'a>,
+    context: InterpreterContext<'a>,
 ) -> Interpreter<'a, I::IntoIter>
 where
     I: IntoIterator<Item = StmtNode<'a>>,
 {
-    Interpreter::new(statements.into_iter())
+    Interpreter::new(statements.into_iter(), context)
 }
 
 pub struct Interpreter<'a, I: Iterator<Item = StmtNode<'a>>> {
@@ -25,22 +28,20 @@ pub struct Interpreter<'a, I: Iterator<Item = StmtNode<'a>>> {
 
 pub struct InterpreterContext<'a> {
     pub(crate) environment: EnvironmentRef<'a>,
+    pub(crate) locals: HashMap<Span, usize>,
 }
 
 impl<'a> Default for InterpreterContext<'a> {
     fn default() -> Self {
         Self {
             environment: Environment::default().into(),
+            locals: HashMap::new(),
         }
     }
 }
 
 impl<'a, I: Iterator<Item = StmtNode<'a>>> Interpreter<'a, I> {
-    fn new(statements: I) -> Self {
-        let context = InterpreterContext {
-            environment: Environment::default().into(),
-        };
-
+    fn new(statements: I, context: InterpreterContext<'a>) -> Self {
         Self {
             context,
             statements,
@@ -132,17 +133,8 @@ impl InterpreterOps {
     ) -> Result<Value<'a>> {
         let span = expr.span;
         let value = match &*expr.item {
-            Expr::Variable { name } => match context.environment.borrow().get(name) {
-                Some(value) => value,
-                None => return Err(SyntaxError::undefined_variable(*name, span)),
-            },
-            Expr::Assign { name, expr } => {
-                let value = Self::eval_expr(context, expr)?;
-                match context.environment.borrow_mut().assign(name, value.clone()) {
-                    Some(_) => value,
-                    None => return Err(SyntaxError::undefined_variable(*name, span)),
-                }
-            }
+            Expr::Variable { name } => Self::get_var(context, expr, name)?,
+            Expr::Assign { name, expr } => Self::assign_var(context, expr, name)?,
             Expr::Literal { lit } => Value::from(*lit),
             Expr::Group { expr } => Self::eval_expr(context, expr)?,
             Expr::Unary { op, expr } => {
@@ -198,6 +190,55 @@ impl InterpreterOps {
         };
 
         Ok(value)
+    }
+
+    // Resolves a var expression either from local or global scope.
+    fn get_var<'a>(
+        context: &mut InterpreterContext<'a>,
+        expr: &ExprNode<'a>,
+        name: &'a str,
+    ) -> Result<Value<'a>> {
+        // resolve variable using local scope info from the Resolver
+        let value = match context.locals.get(&expr.span) {
+            Some(distance) => match context.environment.borrow().get_at(name, *distance) {
+                Some(value) => value,
+                None => return Err(SyntaxError::undefined_variable(name, expr.span)),
+            },
+            None => match context.environment.borrow().get_global(name) {
+                Some(value) => value,
+                None => return Err(SyntaxError::undefined_variable(name, expr.span)),
+            },
+        };
+        Ok(value)
+    }
+
+    fn assign_var<'a>(
+        context: &mut InterpreterContext<'a>,
+        expr: &ExprNode<'a>,
+        name: &'a str,
+    ) -> Result<Value<'a>> {
+        let value = Self::eval_expr(context, expr)?;
+
+        match context.locals.get(&expr.span) {
+            Some(distance) => {
+                match context
+                    .environment
+                    .borrow_mut()
+                    .assign_at(name, value.clone(), *distance)
+                {
+                    Some(_) => Ok(value),
+                    None => Err(SyntaxError::undefined_variable(name, expr.span)),
+                }
+            }
+            None => match context
+                .environment
+                .borrow_mut()
+                .assign_global(name, value.clone())
+            {
+                Some(_) => Ok(value),
+                None => Err(SyntaxError::undefined_variable(name, expr.span)),
+            },
+        }
     }
 }
 

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -8,7 +8,10 @@ use crate::{
     Result,
 };
 
-pub fn interpreter<'a, I>(statements: I) -> Interpreter<'a, I::IntoIter>
+pub fn interpreter<'a, I>(
+    statements: I,
+    _context: InterpreterContext<'a>,
+) -> Interpreter<'a, I::IntoIter>
 where
     I: IntoIterator<Item = StmtNode<'a>>,
 {
@@ -20,7 +23,7 @@ pub struct Interpreter<'a, I: Iterator<Item = StmtNode<'a>>> {
     statements: I,
 }
 
-pub(crate) struct InterpreterContext<'a> {
+pub struct InterpreterContext<'a> {
     pub(crate) environment: EnvironmentRef<'a>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,14 +7,16 @@ mod expr;
 mod interp;
 mod node;
 mod parser;
+mod resolver;
 mod scanner;
 mod stmt;
 mod util;
 mod value;
 
+use crate::interp::interpreter;
 use crate::parser::parser;
+use crate::resolver::resolver;
 use error::{BolloxError, BolloxErrors};
-use interp::interpreter;
 use std::cell::Cell;
 
 pub use scanner::Source;
@@ -45,6 +47,15 @@ where
 
     // parse (tokens -> statements)
     let statements = parser(source, tokens).filter_map(|stmt| match stmt {
+        Ok(e) => Some(e),
+        Err(e) => {
+            store_err(e);
+            None
+        }
+    });
+
+    // resolver (statements -> statements)
+    let statements = resolver(statements).filter_map(|stmt| match stmt {
         Ok(e) => Some(e),
         Err(e) => {
             store_err(e);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -319,7 +319,7 @@ impl<'a, I: Iterator<Item = Tok>> Parser<'a, I> {
         let span = start.union(end);
         let lambda = Expr::lambda(params, body, span.clone().into()).at(span);
 
-        return Ok(lambda);
+        Ok(lambda)
     }
     // assignment -> IDENTIFIER "=" assignment | logic_or ;
     fn assignment(&mut self) -> Result<ExprNode<'a>> {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -184,11 +184,12 @@ impl ResolverOps {
 
 pub(crate) struct ResolverContext<'a> {
     interpreter: InterpreterContext<'a>,
-    // A scope maps variables to their state, where
-    // `false` indicates that the variable exists,
-    // but is not yet initialized.
+    // A scope maps variables within that scope to their state.
+    // Variables are first declared and then defined. Those two
+    // states are not necessarily entered in the same statement.
     scopes: Vec<HashMap<&'a str, VarState>>,
-    // Function call depth
+    // Tracks the depth of function call nesting. This is used
+    // to figure out if the program returns from the global scope.
     depth: usize,
 }
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,0 +1,48 @@
+use crate::{
+    callable::{Callable, Function},
+    env::{Environment, EnvironmentRef},
+    error::{BolloxError, RuntimeError, SyntaxError},
+    expr::{BinaryOp, Expr, ExprNode, LogicalOp, UnaryOp},
+    stmt::{Stmt, StmtNode},
+    Result,
+};
+
+pub fn resolver<'a, I>(statements: I) -> Resolver<'a, I::IntoIter>
+where
+    I: IntoIterator<Item = StmtNode<'a>>,
+{
+    Resolver::new(statements.into_iter())
+}
+
+pub struct Resolver<'a, I: IntoIterator<Item = StmtNode<'a>>> {
+    statements: I,
+}
+
+impl<'a, I: Iterator<Item = StmtNode<'a>>> Resolver<'a, I> {
+    fn new(statements: I) -> Self {
+        Self { statements }
+    }
+}
+
+impl<'a, I: Iterator<Item = StmtNode<'a>>> Iterator for Resolver<'a, I> {
+    type Item = Result<StmtNode<'a>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.statements
+            .next()
+            .map(|stmt| match ResolverOps::eval_stmt(stmt) {
+                Ok(stmt) => Ok(stmt),
+                Err(e) => Err(e),
+            })
+    }
+}
+
+type ResolverResult<'a> = Result<StmtNode<'a>>;
+
+pub(crate) struct ResolverOps;
+
+impl ResolverOps {
+    pub(crate) fn eval_stmt<'a>(stmt: StmtNode<'a>) -> ResolverResult<'a> {
+        Ok(stmt)
+    }
+}

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use crate::{
+    error::ResolverError,
     expr::{Expr, ExprNode},
     interp::InterpreterContext,
     node::Node,
@@ -112,7 +113,7 @@ impl ResolverOps {
                     context.resolve_local(expr, name);
                     Ok(())
                 }
-                _ => todo!("error: can't read local variable in its own initializer"),
+                _ => Err(ResolverError::undefined_variable(*name, expr.span)),
             },
             Expr::Assign { name, expr } => {
                 Self::resolve_expr(context, expr)?;

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,48 +1,234 @@
+use std::collections::HashMap;
+
 use crate::{
-    callable::{Callable, Function},
-    env::{Environment, EnvironmentRef},
-    error::{BolloxError, RuntimeError, SyntaxError},
-    expr::{BinaryOp, Expr, ExprNode, LogicalOp, UnaryOp},
-    stmt::{Stmt, StmtNode},
+    expr::{Expr, ExprNode},
+    interp::InterpreterContext,
+    node::Node,
+    stmt::{FunctionDeclaration, Stmt, StmtNode},
     Result,
 };
 
-pub fn resolver<'a, I>(statements: I) -> Resolver<'a, I::IntoIter>
+type ResolverResult<'a> = Result<StmtNode<'a>>;
+
+pub fn resolver<'a, 'i, I>(
+    statements: I,
+    interpreter: InterpreterContext<'a>,
+) -> Resolver<'a, I::IntoIter>
 where
     I: IntoIterator<Item = StmtNode<'a>>,
 {
-    Resolver::new(statements.into_iter())
+    Resolver::new(statements.into_iter(), interpreter)
 }
 
 pub struct Resolver<'a, I: IntoIterator<Item = StmtNode<'a>>> {
+    context: ResolverContext<'a>,
     statements: I,
 }
 
 impl<'a, I: Iterator<Item = StmtNode<'a>>> Resolver<'a, I> {
-    fn new(statements: I) -> Self {
-        Self { statements }
+    fn new(statements: I, interpreter: InterpreterContext<'a>) -> Self {
+        Self {
+            context: ResolverContext::new(interpreter),
+            statements,
+        }
+    }
+
+    pub(crate) fn interpreter_context(self) -> InterpreterContext<'a> {
+        self.context.interpreter
     }
 }
 
 impl<'a, I: Iterator<Item = StmtNode<'a>>> Iterator for Resolver<'a, I> {
-    type Item = Result<StmtNode<'a>>;
+    type Item = ResolverResult<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.statements
-            .next()
-            .map(|stmt| match ResolverOps::eval_stmt(stmt) {
-                Ok(stmt) => Ok(stmt),
+        self.statements.next().map(|stmt| {
+            match ResolverOps::resolve_stmt(&mut self.context, &stmt) {
+                Ok(()) => Ok(stmt),
                 Err(e) => Err(e),
-            })
+            }
+        })
     }
 }
-
-type ResolverResult<'a> = Result<StmtNode<'a>>;
 
 pub(crate) struct ResolverOps;
 
 impl ResolverOps {
-    pub(crate) fn eval_stmt<'a>(stmt: StmtNode<'a>) -> ResolverResult<'a> {
-        Ok(stmt)
+    pub(crate) fn resolve_stmt<'a>(
+        context: &mut ResolverContext<'a>,
+        stmt: &StmtNode<'a>,
+    ) -> Result<()> {
+        match &*stmt.item {
+            Stmt::Block(stmts) => Self::resolve_block(context, stmts),
+            Stmt::Expression(expr) => Self::resolve_expr(context, expr),
+            Stmt::Print(expr) => Self::resolve_expr(context, expr),
+            Stmt::Var(name, initializer) => Self::resolve_variable(context, name, initializer),
+            Stmt::Func(declaration) => Self::resolve_function(context, declaration),
+            Stmt::If(condition, then_branch, else_branch) => {
+                Self::resolve_expr(context, condition)?;
+                Self::resolve_stmt(context, then_branch)?;
+                if let Some(else_branch) = else_branch {
+                    Self::resolve_stmt(context, else_branch)?;
+                }
+                Ok(())
+            }
+            Stmt::While(condition, statement) => {
+                Self::resolve_expr(context, condition)?;
+                Self::resolve_stmt(context, statement)?;
+                Ok(())
+            }
+            Stmt::Return(value) => {
+                if let Some(value) = value {
+                    Self::resolve_expr(context, value)?
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn resolve_expr<'a>(context: &mut ResolverContext<'a>, expr: &ExprNode<'a>) -> Result<()> {
+        match &*expr.item {
+            Expr::Unary { op: _, expr } => Self::resolve_expr(context, expr),
+            Expr::Binary { lhs, op: _, rhs } => {
+                Self::resolve_expr(context, lhs)?;
+                Self::resolve_expr(context, rhs)?;
+                Ok(())
+            }
+            Expr::Call { callee, args } => {
+                Self::resolve_expr(context, callee)?;
+                args.iter()
+                    .map(|arg| Self::resolve_expr(context, arg))
+                    .collect::<Result<()>>()?;
+                Ok(())
+            }
+            Expr::Logical { lhs, op: _, rhs } => {
+                Self::resolve_expr(context, lhs)?;
+                Self::resolve_expr(context, rhs)?;
+                Ok(())
+            }
+            Expr::Group { expr } => Self::resolve_expr(context, expr),
+            Expr::Literal { lit: _ } => Ok(()),
+            Expr::Variable { name } => match context.var_state(name) {
+                Some(VarState::Defined) => Ok(context.resolve_local(expr, name)),
+                _ => todo!("error: can't read local variable in its own initializer"),
+            },
+            Expr::Assign { name, expr } => {
+                Self::resolve_expr(context, expr)?;
+                Ok(context.resolve_local(expr, name))
+            }
+            Expr::Lambda { declaration } => Self::resolve_function(context, declaration),
+        }
+    }
+
+    fn resolve_stmts<'a>(context: &mut ResolverContext<'a>, stmts: &[StmtNode<'a>]) -> Result<()> {
+        stmts
+            .iter()
+            .map(|stmt| Self::resolve_stmt(context, stmt))
+            .collect::<Result<()>>()
+    }
+
+    fn resolve_block<'a>(context: &mut ResolverContext<'a>, stmts: &[StmtNode<'a>]) -> Result<()> {
+        context.begin_scope();
+        Self::resolve_stmts(context, stmts)?;
+        context.end_scope();
+        Ok(())
+    }
+
+    fn resolve_variable<'a>(
+        context: &mut ResolverContext<'a>,
+        name: &Node<&'a str>,
+        initializer: &Option<ExprNode<'a>>,
+    ) -> Result<()> {
+        context.declare(name.item);
+        if let Some(expr) = initializer {
+            Self::resolve_expr(context, expr)?;
+        }
+        context.define(name.item);
+        Ok(())
+    }
+
+    fn resolve_function<'a>(
+        context: &mut ResolverContext<'a>,
+        declaration: &FunctionDeclaration<'a>,
+    ) -> Result<()> {
+        // resolve function name first, to allow for recursive calls
+        context.declare(declaration.name.item);
+        context.define(declaration.name.item);
+
+        context.begin_scope();
+        declaration.params.iter().for_each(|param| {
+            context.declare(param.item);
+            context.define(param.item);
+        });
+        Self::resolve_stmts(context, &*declaration.body)?;
+        context.end_scope();
+        Ok(())
+    }
+}
+
+pub(crate) struct ResolverContext<'a> {
+    interpreter: InterpreterContext<'a>,
+    // A scope maps variables to their state, where
+    // `false` indicates that the variable exists,
+    // but is not yet initialized.
+    scopes: Vec<HashMap<&'a str, VarState>>,
+}
+
+#[derive(Clone, Copy)]
+enum VarState {
+    Declared,
+    Defined,
+}
+
+impl<'a> ResolverContext<'a> {
+    fn new(interpreter: InterpreterContext<'a>) -> Self {
+        Self {
+            interpreter,
+            scopes: Vec::new(),
+        }
+    }
+
+    // Creates a new block scope and pushes it to the stack.
+    fn begin_scope(&mut self) {
+        self.scopes.push(HashMap::new());
+    }
+
+    // Pops the last scope from the stack.
+    fn end_scope(&mut self) {
+        self.scopes.pop();
+    }
+
+    fn declare(&mut self, name: &'a str) {
+        match self.scopes.last_mut() {
+            Some(scope) => scope.insert(name, VarState::Declared),
+            None => None,
+        };
+    }
+
+    fn define(&mut self, name: &'a str) {
+        match self.scopes.last_mut() {
+            Some(scope) => scope.insert(name, VarState::Defined),
+            None => None,
+        };
+    }
+
+    fn var_state(&self, name: &'a str) -> Option<VarState> {
+        match self.scopes.last() {
+            Some(scope) => scope.get(name).cloned(),
+            None => None,
+        }
+    }
+
+    // Finds the innermost scope, that contains the given variable name.
+    // Uses the index of that scope to resolve the expression.
+    fn resolve_local(&mut self, _expr: &ExprNode<'a>, name: &'a str) {
+        let _depth = self
+            .scopes
+            .iter()
+            .rev()
+            .position(|scope| scope.contains_key(name))
+            .unwrap();
+
+        todo!("interpreter.resolve(expr, depth)");
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -23,7 +23,7 @@ impl Token {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Span {
     pub offset: usize,
     pub len: usize,


### PR DESCRIPTION
- Add pass-through resolver
- Implement resolve logic for stmts and exprs
- Use resolver output in interpreter
- Make clippy happy
- Add ResolverError
- Catch redefined vars/funcs error
- Throw on top-level return statement
